### PR TITLE
Fix typo eror in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ render() {
    }
  };
  
- const settingsChanged = (changedSettings) {
+ const settingsChanged = (changedSettings) => {
    // this is triggered onChange of the inputs
  };
 


### PR DESCRIPTION
Dear Dstuecken.

I fixed a quite simple typo of example code in `README.md`.

### Before

```js
 const settingsChanged = (changedSettings) {
   // this is triggered onChange of the inputs
 };
```

### After
```js
 const settingsChanged = (changedSettings) => {
   // this is triggered onChange of the inputs
 };
```

## Real working snippet in `/example` code.

```Js
    // React if a single setting changed
    this._settingsChanged = (ev) => {

    }
```

Thanks, Taekeun