### PR TITLE
Travis build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,5 @@ cache:
 node_js:
   - "10"
   - "12"
-before_script:
-    - export DISPLAY=:99.0
-    - sh -e /etc/init.d/xvfb start
 script:
   - npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "7"
-  - "8"
+  - "10"
+  - "12"
 before_script:
     - export DISPLAY=:99.0
     - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
### Testing on current active Node versions
As you can see [here](https://nodejs.org/en/about/releases/), the current LTS versions for node are 8, 10 and 13. Version 8 being in maintenance and expiring at the end of this year, we should run tests on the Active LTS versions wich are 10 and 12.

### Failing command
 If I'm not missing anything, there's no reasons to have a display context as there's no end-to-end tests.
So we can just remove the xvfb service starting and the export commands to fix the build.

**Can you confirm those points? Thanks**